### PR TITLE
Updating deprecated L.Mixin.Events reference

### DIFF
--- a/src/locationfilter.js
+++ b/src/locationfilter.js
@@ -91,7 +91,7 @@ L.Control.ButtonContainer = L.Control.extend({
 });
 
 L.LocationFilter = L.Class.extend({
-    includes: L.Mixin.Events,
+    includes: L.Evented,
 
     options: {
         enableButton: {


### PR DESCRIPTION
> Deprecated include of L.Mixin.Events: this property will be removed in future releases, please inherit from L.Evented instead.

https://github.com/kajic/leaflet-locationfilter/pull/24