### PR TITLE
Fix the Fixed State to work

### DIFF
--- a/src/locationfilter.css
+++ b/src/locationfilter.css
@@ -17,6 +17,10 @@ div.leaflet-marker-icon.location-filter.move-marker {
     background: url( img/move-handle.png ) no-repeat;
     cursor: move;
 }
+div.leaflet-marker-icon.location-filter.resize-marker.ne.hide-marker,
+div.leaflet-marker-icon.location-filter.resize-marker.nw.hide-marker,
+div.leaflet-marker-icon.location-filter.resize-marker.sw.hide-marker,
+div.leaflet-marker-icon.location-filter.resize-marker.se.hide-marker,
 div.leaflet-marker-icon.location-filter.move-marker.hide-marker {
     display: none;
 }


### PR DESCRIPTION
## Expected Behavior
If the `fixed` option is true, the rectangle cannot be resized.
https://deton.github.io/leaflet-locationfilter/after.html?fixed=1

## Current Behavior
Fixed State doesn't work.
resize-markers are shown and are usable for resizing even if `fixed: true`.
https://deton.github.io/leaflet-locationfilter/before.html?fixed=1

## Cause
resize-marker with hide-marker class is missing in locationfilter.css.

## Solution
This pull request adds resize-marker with hide-marker class to locationfilter.css.

```diff
+div.leaflet-marker-icon.location-filter.resize-marker.ne.hide-marker,
+div.leaflet-marker-icon.location-filter.resize-marker.nw.hide-marker,
+div.leaflet-marker-icon.location-filter.resize-marker.sw.hide-marker,
+div.leaflet-marker-icon.location-filter.resize-marker.se.hide-marker,
 div.leaflet-marker-icon.location-filter.move-marker.hide-marker {
     display: none;
 }
```
